### PR TITLE
SIMD friendly iterate

### DIFF
--- a/src/vector.jl
+++ b/src/vector.jl
@@ -52,3 +52,9 @@ function Base.copy!(dest::BlobVector{T}, doff::Int, src::BlobVector{T}, soff::In
         for i in n-1:-1:0 dest[doff+i] = src[soff+i] end
     end
 end
+
+# iterate interface
+
+@inline function Base.iterate(blob::BlobVector, i=1)
+    (i % UInt) - 1 < length(blob) ? (@inbounds blob[i], i + 1) : nothing
+end


### PR DESCRIPTION
Added an implementation for iterate that should compile nicely into SIMD code. It is almost an exact copy of the implementation that is used for Arrays (which can be found in array.jl in Base). For some reason the default iterate function is not as SIMD friendly.