### PR TITLE
Convenience functions

### DIFF
--- a/src/blob.jl
+++ b/src/blob.jl
@@ -12,6 +12,14 @@ struct Blob{T}
     end
 end
 
+function Blob(ref::Base.RefValue{T}) where T
+    Blob{T}(pointer_from_objref(ref), 0, sizeof(T))
+end
+
+function Blob(base::Ptr{T}, offset::Int64 = 0, limit::Int64 = sizeof(T)) where {T}
+    Blob{T}(Ptr{Nothing}(base), offset, limit)
+end
+
 function Blob{T}(blob::Blob) where T
     Blob{T}(getfield(blob, :base), getfield(blob, :offset), getfield(blob, :limit))
 end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -82,6 +82,16 @@ function malloc(::Type{T}, args...)::Blob{T} where T
 end
 
 """
+    calloc(::Type{T}, args...)::Blob{T} where T
+
+Allocate a zero-initialized `Blob{T}`.
+"""
+function calloc(::Type{T}, args...)::Blob{T} where T
+    size = self_size(T) + child_size(T, args...)
+    Blob{T}(Libc.calloc(1, size), 0, size)
+end
+
+"""
     malloc_and_init(::Type{T}, args...)::Blob{T} where T
 
 Allocate and initialize a new `Blob{T}`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,21 @@ foo.y[] = 2.5
 @test foo == foo
 @test pointer(foo.y) == pointer(foo) + sizeof(Int64)
 
+foo2_ref = Ref(Foo(42, 3.14))
+foo2 = Blob(foo2_ref)
+@test foo2[] == Foo(42, 3.14)
+
+foo3_arr = [Foo(1, -1), Foo(2, -2)]
+foo31 = Blob(pointer(foo3_arr), 0, 2sizeof(Foo))
+foo32 = Blob(pointer(foo3_arr), sizeof(Foo), 2sizeof(Foo))
+foo33 = Blob(pointer(foo3_arr, 2))
+@test foo31[] == Foo(1, -1)
+@test foo32[] == Foo(2, -2)
+@test foo33[] == Foo(2, -2)
+
+foo4 = Blobs.calloc(Foo)
+@test foo4[] == Foo(0, 0)
+
 # nested Blob
 
 bfoo = Blobs.malloc_and_init(Blob{Foo})


### PR DESCRIPTION
I'm working with some C libraries where sometimes I end up with a reference to an object I want to use via Blobs interface, or sometimes want to zero-initialize some Blobs-allocated objects. I added some simple convenience functions to that effect.

I am not sure if understand the inner workings of `Blobs` enough to have implemented things sensibly, so careful review is appreciated.

~I can take an initial pass at writing tests for these once I know I'm on the right track and this PR likely to get accepted.~ Tests added.