### PR TITLE
inbounds copy! for BlobVector

### DIFF
--- a/src/vector.jl
+++ b/src/vector.jl
@@ -45,8 +45,15 @@ end
 
 # copying, with correct handling of overlapping regions
 # TODO use memcopy
-function Base.copy!(dest::BlobVector{T}, doff::Int, src::BlobVector{T}, soff::Int, n::Int) where T
-    if doff < soff
+function Base.copy!(
+    dest::BlobVector{T}, doff::Int, src::BlobVector{T}, soff::Int, n::Int
+) where T
+    @boundscheck begin
+        if doff < 1 || doff + n - 1 > length(dest) || soff < 1 || soff + n - 1 > length(src)
+            throw(BoundsError([dest, src], [doff, soff, n]))
+        end
+    end
+    @inbounds if doff < soff
         for i in 0:n-1 dest[doff+i] = src[soff+i] end
     else
         for i in n-1:-1:0 dest[doff+i] = src[soff+i] end

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -49,14 +49,16 @@ function Base.copy!(
     dest::BlobVector{T}, doff::Int, src::BlobVector{T}, soff::Int, n::Int
 ) where T
     @boundscheck begin
-        if doff < 1 || doff + n - 1 > length(dest) || soff < 1 || soff + n - 1 > length(src)
-            throw(BoundsError([dest, src], [doff, soff, n]))
+        if doff < 1 || doff + n - 1 > length(dest)
+            throw(BoundsError(dest, doff:doff+n-1))
+        elseif soff < 1 || soff + n - 1 > length(src)
+            throw(BoundsError(src, soff:soff+n-1))
         end
     end
-    @inbounds if doff < soff
-        for i in 0:n-1 dest[doff+i] = src[soff+i] end
+    if doff < soff
+        @inbounds for i in 0:n-1 dest[doff+i] = src[soff+i] end
     else
-        for i in n-1:-1:0 dest[doff+i] = src[soff+i] end
+        @inbounds for i in n-1:-1:0 dest[doff+i] = src[soff+i] end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,8 @@ copy!(bv3, 4, bv3, 1, 2)
 @test bv3 == [1,2,3,1,2]
 copy!(bv3, 2, bv3, 1, 4)
 @test bv3 == [1,1,2,3,1]
+copy!(bv3, 1, bv3, 2, 4)
+@test bv3 == [1,2,3,1,1]
 
 @test_throws BoundsError copy!(bv3, 2, bv3, 1, 5)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,19 @@ copy!(bv2, 2, bv, 1, 2)
 @test_throws BoundsError copy!(bv2, 1, bv, 0, 3)
 @test_throws BoundsError copy!(bv2, 0, bv, 0, 4)
 
+# Copy to self
+bv3 = Blobs.malloc_and_init(BlobVector{Int}, 5)[]
+for i in 1:5
+    bv3[i] = i
+end
+
+copy!(bv3, 4, bv3, 1, 2)
+@test bv3 == [1,2,3,1,2]
+copy!(bv3, 2, bv3, 1, 4)
+@test bv3 == [1,1,2,3,1]
+
+@test_throws BoundsError copy!(bv3, 2, bv3, 1, 5)
+
 # BlobBitVector
 
 @test Blobs.self_size(BlobBitVector) == 16

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,20 @@ bv[3] = Foo(3, 3.3)
 # test interior pointers
 @test pointer(bbv[2]) - pointer(bv.data) == Blobs.self_size(Foo)
 
+bbv2 = Blobs.malloc_and_init(BlobVector{Foo}, 3)
+bv2 = bbv2[]
+
+copy!(bv2, 1, bv, 1, 3)
+@test bv == bv2
+
+copy!(bv2, 2, bv, 1, 2)
+@test bv[1:2] == bv2[2:3]
+
+@test_throws BoundsError copy!(bv2, 0, bv, 1, 3)
+@test_throws BoundsError copy!(bv2, 1, bv, 1, 4)
+@test_throws BoundsError copy!(bv2, 1, bv, 0, 3)
+@test_throws BoundsError copy!(bv2, 0, bv, 0, 4)
+
 # BlobBitVector
 
 @test Blobs.self_size(BlobBitVector) == 16


### PR DESCRIPTION
This pull request changes `copy!` so that it will perform an optional `@boundscheck`, and then proceed to copy data `@inbounds`. Can speedup copying `BlobVectors` by a factor of ~3x on my machine.