### PR TITLE
Fix the UUID to match General Registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Blobs"
-uuid = "2063b8be-a4ad-11e8-1fb9-93d01944c8ed"
-authors = ["Jamie Brandon <jamie@scattered-thoughts.net>"]
+uuid = "163b9779-6631-5f90-a265-3de947924de8"
+authors = []
 version = "0.4.0"
 
 [deps]


### PR DESCRIPTION
Per the conversation, here:
 https://github.com/RelationalAI-oss/Blobs.jl/commit/4cdae67d22130f11a8609a825590e7535a3020a8#commitcomment-39152075

Blobs was somehow registered under a different UUID!
https://github.com/JuliaRegistries/General/blob/e5350983e55c7cafa71f3cfcd783e9120bc8d2d6/B/Blobs/Package.toml#L2

It looks like the orignal PR that added the Project.toml didn't use the right uuid:
https://github.com/RelationalAI-oss/Blobs.jl/commit/8c119de63695d765ef5d5483a6819f459b2987a3#diff-910a7b3ca0075d545dcec45cb7335ca9