### PR TITLE
Fixup Project.toml for Julia Registry: Add [compat], enable CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,18 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 00 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'
+

--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,7 @@ version = "0.4.0"
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+MacroTools = "0.5"
+julia = "1.3"


### PR DESCRIPTION
Added `[compat]` section to Project.toml for our deps.

Followed instructions on https://github.com/bcbi/CompatHelper.jl to enable CompatHelper for this repo (which will send PRs to the repo to bump compat upper-bounds as new package versions are released).
