### PR TITLE
Speed up copy! by using memmove

### DIFF
--- a/src/vector.jl
+++ b/src/vector.jl
@@ -56,14 +56,14 @@ function Base.copy!(
     end
     # Use memmove for speedy copying. Note: this correctly handles overlapping regions.
     blob_size = Blobs.self_size(T)
-ccall(
-    :memmove,
-    Ptr{Cvoid},
-    (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-    Base.pointer(dest.data) + (doff - 1) * blob_size,
-    Base.pointer(src.data) + (soff - 1) * blob_size,
-    n * blob_size,
-)
+    ccall(
+        :memmove,
+        Ptr{Cvoid},
+        (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
+        Base.pointer(dest.data) + (doff - 1) * blob_size,
+        Base.pointer(src.data) + (soff - 1) * blob_size,
+        n * blob_size,
+    )
 end
 
 # iterate interface

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -56,10 +56,14 @@ function Base.copy!(
     end
     # Use memmove for speedy copying. Note: this correctly handles overlapping regions.
     blob_size = Blobs.self_size(T)
-    ccall(:memmove, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
-          Base.pointer(dest.data) + (doff - 1) * blob_size,
-          Base.pointer(src.data) + (soff - 1) * blob_size,
-          n * blob_size)
+ccall(
+    :memmove,
+    Ptr{Cvoid},
+    (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
+    Base.pointer(dest.data) + (doff - 1) * blob_size,
+    Base.pointer(src.data) + (soff - 1) * blob_size,
+    n * blob_size,
+)
 end
 
 # iterate interface

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -44,7 +44,6 @@ Base.@propagate_inbounds function Base.setindex!(blob::BlobVector{T}, v, i::Int)
 end
 
 # copying, with correct handling of overlapping regions
-# TODO use memcopy
 function Base.copy!(
     dest::BlobVector{T}, doff::Int, src::BlobVector{T}, soff::Int, n::Int
 ) where T
@@ -55,11 +54,12 @@ function Base.copy!(
             throw(BoundsError(src, soff:soff+n-1))
         end
     end
-    if doff < soff
-        @inbounds for i in 0:n-1 dest[doff+i] = src[soff+i] end
-    else
-        @inbounds for i in n-1:-1:0 dest[doff+i] = src[soff+i] end
-    end
+    # Use memmove for speedy copying. Note: this correctly handles overlapping regions.
+    blob_size = Blobs.self_size(T)
+    ccall(:memmove, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
+          Base.pointer(dest.data) + (doff - 1) * blob_size,
+          Base.pointer(src.data) + (soff - 1) * blob_size,
+          n * blob_size)
 end
 
 # iterate interface


### PR DESCRIPTION
Take care of a TODO to replace a manual copy of elements (via a loop) with a call to memmove. 

For completeness: the TODO was for memcpy, but memmove is preferable, since it can handle overlaps. For reference, see also how [memmove is used in Julia's array.jl](https://github.com/JuliaLang/julia/blob/master/base/array.jl#L247):