### PR TITLE
This resolves an issue created by a minor breaking chain in Julia 1.6.

### DIFF
--- a/src/blob.jl
+++ b/src/blob.jl
@@ -154,7 +154,7 @@ end
 
 # syntax sugar
 
-function Base.propertynames(::Blob{T}, private=false) where T
+function Base.propertynames(::Blob{T}, private::Bool=false) where T
     fieldnames(T)
 end
 


### PR DESCRIPTION
There is a minor breaking change in Julia 1.6 where the argument [private] of the function Base.propertynames is now forced to be Bool by default. The corresponding information is provided in the following links:
1] https://github.com/JuliaLang/julia/pull/37550
2] https://github.com/JuliaLang/julia/commit/47d6067ffe37d9693fb90a351a592bb3cfd6a3e6

This results into a MethodError where it says that the definition of function Base.propertynames is ambiguous:
```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.6.1 (2021-04-23)
_/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using Blobs

julia> struct Foo
       x::Int64
       y::Float64
       end

julia> p = Libc.malloc(sizeof(Foo))
Ptr{Nothing} @0x00000000013ab670

julia> foo = Blob{Foo}(p,0,sizeof(Foo))
Blob{Foo}(Ptr{Nothing} @0x00000000013ab670, 0, 16)

julia> propertynames(foo, false)
ERROR: MethodError: propertynames(::Blob{Foo}, ::Bool) is ambiguous. Candidates:
  propertynames(x, private::Bool) in Base at reflection.jl:1581
  propertynames(::Blob{T}, private) where T in Blobs at […]/src/blob.jl:157
Possible fix, define
  propertynames(::Blob{T}, ::Bool) where T
Stacktrace:
[1] top-level scope
   @ REPL[5]:1
```

Consequently, this needs to be updated in Blobs. The line 
```julia
function Base.propertynames(::Blob{T}, private=false) where T
```
should be changed into 
```julia
function Base.propertynames(::Blob{T}, private::Bool=false) where T
```

This is consistent with how other packages have handled this:
3] https://github.com/JuliaAtoms/AtomicLevels.jl/pull/77/commits/388d714a6ef18117eec2072cc451db79432ac85c