### PR TITLE
getindex support for Blob{Tuple} + pointer(::BlobVector)

### DIFF
--- a/src/blob.jl
+++ b/src/blob.jl
@@ -95,6 +95,13 @@ end
     end
 end
 
+@inline function Base.getindex(blob::Blob{T}, i::Int) where {T}
+    @boundscheck if i < 1 || i > fieldcount(T)
+        throw(BoundsError(blob, i))
+    end
+    return Blob{fieldtype(T, i)}(blob + Blobs.blob_offset(T, i))
+end
+
 Base.@propagate_inbounds function Base.setindex!(blob::Blob{T}, value::T) where T
     boundscheck(blob)
     unsafe_store!(blob, value)

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -4,6 +4,10 @@ struct BlobVector{T} <: AbstractArray{T, 1}
     length::Int64
 end
 
+function Base.pointer(bv::BlobVector{T}, i::Integer=1) where {T}
+    return get_address(bv, i)
+end
+
 Base.@propagate_inbounds function get_address(blob::BlobVector{T}, i::Int)::Blob{T} where T
     @boundscheck begin
         (0 < i <= blob.length) || throw(BoundsError(blob, i))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,11 @@ copy!(bv2, 2, bv, 1, 2)
 @test_throws BoundsError copy!(bv2, 1, bv, 0, 3)
 @test_throws BoundsError copy!(bv2, 0, bv, 0, 4)
 
+@test pointer(bv) == pointer(bv, 1)
+for i in 1:length(bv)
+    @test unsafe_load(pointer(bv, i)) == bv[i]
+end
+
 # Copy to self
 bv3 = Blobs.malloc_and_init(BlobVector{Int}, 5)[]
 for i in 1:5
@@ -306,6 +311,12 @@ bt = Blobs.malloc_and_init(Tuple{Int64,Int64})
 bt[] = (2,3)
 @test bt[] == (2,3)
 @test bt[][1] == 2
+
+@test bt[1][] == 2
+@test bt[2][] == 3
+bt[2][] = 42
+@test bt[2][] == 42
+@test bt[][2] == 42
 
 # Structs inside tuples
 struct Toto{N}


### PR DESCRIPTION
This PR enables the following things:

#### `getindex` support for `Blob{Tuple}`
You can now derive the `Blob` of a field in a tuple by using simple `getindex` operations on the `Blob` of that tuple. e.g.:

```
b = Blobs.malloc(Tuple{Int,Int})
b[1][] = 1
b[2][] = 2
@test b[] == (1, 2)
```

#### `pointer` support for `BlobVector`
This PR adds an implementation for `Base.pointer` for `BlobVector`, which works the same way as it does for `Vector`. 