### PR TITLE
Reduce generated functions: getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Blobs"
 uuid = "163b9779-6631-5f90-a265-3de947924de8"
 authors = []
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,9 @@ ReTestItems = "1"
 julia = "1.3"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ReTestItems", "Test"]
+test = ["BenchmarkTools", "ReTestItems", "Test"]

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -150,7 +150,7 @@ end
 function _unsafe_load_fields(blob::Blob{T}, ::Val{I}) where {T, I}
     @inline
     types = fieldnames(T)
-    return (_unsafe_load_fields(blob, Val(I-1))..., unsafe_load(getindex(blob, Val(types[I]))))
+    return (_unsafe_load_fields(blob, Val(I-1))..., unsafe_load(getindex(blob, types[I])))
 end
 
 @inline function Base.unsafe_store!(blob::Blob{T}, value::T) where {T}
@@ -170,7 +170,7 @@ function _unsafe_store_struct!(blob::Blob{T}, value::T, ::Val{I}) where {T, I}
     @inline
     types = fieldnames(T)
     _unsafe_store_struct!(blob, value, Val(I-1))
-    unsafe_store!(getindex(blob, Val(types[I])), getproperty(value, types[I]))
+    unsafe_store!(getindex(blob, types[I]), getproperty(value, types[I]))
     nothing
 end
 # Recursive function for tuples is equivalent to unrolled via `@generated`.
@@ -182,7 +182,7 @@ end
 function _unsafe_store_tuple!(blob::Blob{T}, value::T, ::Val{I}) where {T<:Tuple, I}
     @inline
     _unsafe_store_struct!(blob, value, Val(I-1))
-    unsafe_store!(getindex(blob, Val(I)), value[I])
+    unsafe_store!(getindex(blob, I), value[I])
     nothing
 end
 
@@ -217,7 +217,7 @@ function rewrite_address(expr)
         else
             error("Impossible?")
         end
-        :(getindex($(rewrite_address(object)), $(Val(fieldname))))
+        :(getindex($(rewrite_address(object)), $(QuoteNode(fieldname))))
     elseif expr.head == :ref
         object = expr.args[1]
         :(getindex($(rewrite_address(object)), $(map(esc, expr.args[2:end])...)))

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -137,7 +137,7 @@ end
 function _unsafe_load_fields(blob::Blob{T}, ::Val{I}) where {T, I}
     @inline
     types = fieldnames(T)
-    return (_unsafe_load_fields(blob, Val(I-1))..., unsafe_load(getindex(blob, Val{types[I]})))
+    return (_unsafe_load_fields(blob, Val(I-1))..., unsafe_load(getindex(blob, Val(types[I]))))
 end
 
 @inline function Base.unsafe_store!(blob::Blob{T}, value::T) where {T}
@@ -157,7 +157,7 @@ function _unsafe_store_struct!(blob::Blob{T}, value::T, ::Val{I}) where {T, I}
     @inline
     types = fieldnames(T)
     _unsafe_store_struct!(blob, value, Val(I-1))
-    unsafe_store!(getindex(blob, Val{types[I]}), getproperty(value, types[I]))
+    unsafe_store!(getindex(blob, Val(types[I])), getproperty(value, types[I]))
     nothing
 end
 # Recursive function for tuples is equivalent to unrolled via `@generated`.
@@ -169,7 +169,7 @@ end
 function _unsafe_store_tuple!(blob::Blob{T}, value::T, ::Val{I}) where {T<:Tuple, I}
     @inline
     _unsafe_store_struct!(blob, value, Val(I-1))
-    unsafe_store!(getindex(blob, Val{I}), value[I])
+    unsafe_store!(getindex(blob, Val(I)), value[I])
     nothing
 end
 
@@ -189,7 +189,7 @@ function Base.getproperty(blob::Blob{T}, field::Symbol) where T
 end
 
 function Base.setproperty!(blob::Blob{T}, field::Symbol, value) where T
-    setindex!(blob, Val{field}, value)
+    setindex!(blob, Val(field), value)
 end
 
 function rewrite_address(expr)
@@ -204,7 +204,7 @@ function rewrite_address(expr)
         else
             error("Impossible?")
         end
-        :(getindex($(rewrite_address(object)), $(Val{fieldname})))
+        :(getindex($(rewrite_address(object)), $(Val(fieldname))))
     elseif expr.head == :ref
         object = expr.args[1]
         :(getindex($(rewrite_address(object)), $(map(esc, expr.args[2:end])...)))

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -147,6 +147,9 @@ end
         _unsafe_store_struct!(blob::Blob{T}, value::T)
     end
 end
+# Split out the part that needs to be a generated function, to minimize the impact on
+# compilation time. If the branch that calls this function is statically eliminated,
+# julia will never compile this, and so we won't pay the overhead for the generator.
 @generated function _unsafe_store_struct!(blob::Blob{T}, value::T) where {T}
     quote
         $(Expr(:meta, :inline))

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -25,7 +25,11 @@ function Blob{T}(blob::Blob) where T
 end
 
 function assert_same_allocation(blob1::Blob, blob2::Blob)
-    @assert getfield(blob1, :base) == getfield(blob2, :base) "These blobs do not share the same allocation: $blob1 - $blob2"
+    @noinline _throw(blob1, blob2) =
+        throw(AssertionError("These blobs do not share the same allocation: $blob1 - $blob2"))
+    if getfield(blob1, :base) != getfield(blob2, :base)
+        _throw(blob1, blob2)
+    end
 end
 
 function Base.pointer(blob::Blob{T}) where T

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -86,11 +86,7 @@ end
 
 # Recursion scales better than splatting for large numbers of fields.
 Base.@assume_effects :foldable @inline function blob_offset(::Type{T}, i::Int) where {T}
-    return _blob_offset(T, i-1)
-end
-Base.@assume_effects :foldable @inline function _blob_offset(::Type{T}, i::Int) where {T}
-    i <= 0 && return 0
-    return _blob_offset(T, i-1) + self_size(fieldtype(T, i))
+    _sum_field_sizes(T, i - 1)
 end
 
 @inline function Base.getindex(blob::Blob{T}, ::Type{Val{field}}) where {T, field}

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -70,7 +70,7 @@ Base.@assume_effects :foldable function self_size(::Type{T}) where T
         sizeof(T)
     else
         # Recursion is the fastest way to compile this, confirmed with benchmarks.
-        # Alternatives considered: 
+        # Alternatives considered:
         # - +(Iterators.map(self_size, fieldtypes(T))...)
         # - runtime_size for-loop (below).
         # Splatting is always slower, and breaks after ~30 fields.
@@ -107,7 +107,7 @@ Base.@assume_effects :foldable function fieldidx(::Type{T}, ::Val{field}) where 
     @assert i !== nothing "$T has no field $field"
     return i
 end
-@inline function Base.getindex(blob::Blob{T}, ::Val{field}) where {T, field}
+@inline function Base.getindex(blob::Blob{T}, field::Symbol) where {T}
     i = fieldidx(T, Val(field))
     FT = fieldtype(T, i)
     Blob{FT}(blob + blob_offset(T, i))
@@ -198,7 +198,7 @@ function Base.propertynames(::Blob{T}, private::Bool=false) where T
 end
 
 function Base.getproperty(blob::Blob{T}, field::Symbol) where T
-    getindex(blob, Val(field))
+    getindex(blob, field)
 end
 
 function Base.setproperty!(blob::Blob{T}, field::Symbol, value) where T

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -76,7 +76,7 @@ Base.@assume_effects :foldable function self_size(::Type{T}) where T
         # Recursion is the fastest way to compile this, confirmed with benchmarks.
         # Alternatives considered:
         # - +(Iterators.map(self_size, fieldtypes(T))...)
-        # - runtime_size for-loop (below).
+        # - _iterative_sum_field_sizes for-loop (below).
         # Splatting is always slower, and breaks after ~30 fields.
         # The for-loop is faster after around 15-30 fields, so we pick an
         # arbitrary cutoff of 20:

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -83,8 +83,8 @@ Base.@assume_effects :foldable function self_size(::Type{T}) where T
         end
     end
 end
-runtime_size(::Type{T}) where T =
-    let out = 0
+function runtime_size(::Type{T}) where T
+    out = 0
     for f in fieldtypes(T)
         out += Blobs.self_size(f)
     end

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -86,13 +86,13 @@ function blob_offset(::Type{T}, i::Int) where {T}
     end)
 end
 
-@generated function Base.getindex(blob::Blob{T}, ::Type{Val{field}}) where {T, field}
+# TODO: I really wish there was a way to assert that this would actually
+# get done at compile time, so we can feel confident removing the at-generated.
+# I've attempted to do this via `@inferred` tests, but that's not fully sufficient.
+@inline function Base.getindex(blob::Blob{T}, ::Type{Val{field}}) where {T, field}
     i = findfirst(isequal(field), fieldnames(T))
-    @assert i != nothing "$T has no field $field"
-    quote
-        $(Expr(:meta, :inline))
-        Blob{$(fieldtype(T, i))}(blob + $(blob_offset(T, i)))
-    end
+    @assert i !== nothing "$T has no field $field"
+    Blob{fieldtype(T, i)}(blob + (blob_offset(T, i)))
 end
 
 @inline function Base.getindex(blob::Blob{T}, i::Int) where {T}

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -102,13 +102,13 @@ Base.@assume_effects :foldable @inline function blob_offset(::Type{T}, i::Int) w
     _recursive_sum_field_sizes(T, Val(i - 1))
 end
 
-Base.@assume_effects :foldable function fieldidx(::Type{T}, ::Val{field}) where {T, field}
+@inline function fieldidx(::Type{T}, field) where T
     i = findfirst(isequal(field), fieldnames(T))
     @assert i !== nothing "$T has no field $field"
     return i
 end
 @inline function Base.getindex(blob::Blob{T}, field::Symbol) where {T}
-    i = fieldidx(T, Val(field))
+    i = fieldidx(T, field)
     FT = fieldtype(T, i)
     Blob{FT}(blob + blob_offset(T, i))
 end

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -85,12 +85,12 @@ Base.@assume_effects :foldable function _sum_field_sizes(::Type{T}, ::Val{i}) wh
 end
 
 # Recursion scales better than splatting for large numbers of fields.
-Base.@assume_effects :foldable function blob_offset(::Type{T}, i::Int) where {T}
+Base.@assume_effects :foldable @inline function blob_offset(::Type{T}, i::Int) where {T}
     return _blob_offset(T, i-1)
 end
-Base.@assume_effects :foldable function _blob_offset(::Type{T}, i::Int) where {T}
+Base.@assume_effects :foldable @inline function _blob_offset(::Type{T}, i::Int) where {T}
     i <= 0 && return 0
-    return blob_offset(T, i-1) + self_size(fieldtype(T, i))
+    return _blob_offset(T, i-1) + self_size(fieldtype(T, i))
 end
 
 @inline function Base.getindex(blob::Blob{T}, ::Type{Val{field}}) where {T, field}

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -84,10 +84,13 @@ Base.@assume_effects :foldable function _sum_field_sizes(::Type{T}, ::Val{i}) wh
     return self_size(fieldtype(T, i)) + _sum_field_sizes(T, Val(i-1))
 end
 
+# Recursion scales better than splatting for large numbers of fields.
 Base.@assume_effects :foldable function blob_offset(::Type{T}, i::Int) where {T}
-    +(0, @splice j in 1:(i-1) begin
-        self_size(fieldtype(T, j))
-    end)
+    return _blob_offset(T, i-1)
+end
+Base.@assume_effects :foldable function _blob_offset(::Type{T}, i::Int) where {T}
+    i <= 0 && return 0
+    return blob_offset(T, i-1) + self_size(fieldtype(T, i))
 end
 
 @inline function Base.getindex(blob::Blob{T}, ::Type{Val{field}}) where {T, field}

--- a/test/type-stability-tests.jl
+++ b/test/type-stability-tests.jl
@@ -1,0 +1,59 @@
+@testitem "type-stability" begin
+    struct Quux
+        x::BlobVector{Int}
+        y::Float64
+    end
+    struct Bar
+        a::Int
+        b::BlobBitVector
+        c::Bool
+        d::BlobVector{Float64}
+        e::Blob{Quux}
+    end
+
+    @test Blobs.self_size(Bar) == 8 + 16 + 1 + 16 + 8 # Blob{Quux} is smaller in the blob
+
+    function Blobs.child_size(::Type{Quux}, x_len::Int64, y::Float64)
+        T = Quux
+        +(Blobs.child_size(fieldtype(T, :x), x_len))
+    end
+
+    function Blobs.child_size(::Type{Bar}, b_len::Int64, c::Bool, d_len::Int64, x_len::Int64, y::Float64)
+        T = Bar
+        +(Blobs.child_size(fieldtype(T, :b), b_len),
+        Blobs.child_size(fieldtype(T, :d), d_len),
+        Blobs.child_size(fieldtype(T, :e), x_len, y))
+    end
+
+    function Blobs.init(quux::Blob{Quux}, free::Blob{Nothing}, x_len::Int64, y::Float64)
+        free = Blobs.init(quux.x, free, x_len)
+        quux.y[] = y
+        free
+    end
+
+    function Blobs.init(bar::Blob{Bar}, free::Blob{Nothing}, b_len::Int64, c::Bool, d_len::Int64, x_len::Int64, y::Float64)
+        free = Blobs.init(bar.b, free, b_len)
+        free = Blobs.init(bar.d, free, d_len)
+        free = Blobs.init(bar.e, free, x_len, y)
+        bar.c[] = c
+        free
+    end
+
+    bar = Blobs.malloc_and_init(Bar, 10, false, 20, 15, 1.5)
+
+    # Test type stability
+    @testset "getindex" begin
+        test_getproperty1(b) = b.e
+        @test @inferred(test_getproperty1(bar)) === bar.e
+        test_getproperty2(b) = b.d
+        @test @inferred(test_getproperty2(bar)) === bar.d
+    end
+
+    @testset "unsafe_load" begin
+        @test @inferred(unsafe_load(bar)) isa Bar
+    end
+
+    @testset "self_size" begin
+        @test @inferred(Blobs.self_size(Bar)) === 49
+    end
+end

--- a/test/type-stability-tests.jl
+++ b/test/type-stability-tests.jl
@@ -56,4 +56,9 @@
     @testset "self_size" begin
         @test @inferred(Blobs.self_size(Bar)) === 49
     end
+
+    @testset "unsafe_store!" begin
+        bar_value = unsafe_load(bar)
+        @test @inferred(Blobs.unsafe_store!(bar, bar_value)) isa Bar
+    end
 end

--- a/test/type-stability-tests.jl
+++ b/test/type-stability-tests.jl
@@ -20,11 +20,11 @@
         +(Blobs.child_size(fieldtype(T, :x), x_len))
     end
 
-    function Blobs.child_size(::Type{Bar}, b_len::Int64, c::Bool, d_len::Int64, x_len::Int64, y::Float64)
+    function Blobs.child_size(::Type{Bar}, b_len::Int64, c::Bool, d_len::Int64, e_len::Int64, y::Float64)
         T = Bar
         +(Blobs.child_size(fieldtype(T, :b), b_len),
         Blobs.child_size(fieldtype(T, :d), d_len),
-        Blobs.child_size(fieldtype(T, :e), x_len, y))
+        Blobs.child_size(fieldtype(T, :e), e_len, y))
     end
 
     function Blobs.init(quux::Blob{Quux}, free::Blob{Nothing}, x_len::Int64, y::Float64)
@@ -33,10 +33,10 @@
         free
     end
 
-    function Blobs.init(bar::Blob{Bar}, free::Blob{Nothing}, b_len::Int64, c::Bool, d_len::Int64, x_len::Int64, y::Float64)
+    function Blobs.init(bar::Blob{Bar}, free::Blob{Nothing}, b_len::Int64, c::Bool, d_len::Int64, e_len::Int64, y::Float64)
         free = Blobs.init(bar.b, free, b_len)
         free = Blobs.init(bar.d, free, d_len)
-        free = Blobs.init(bar.e, free, x_len, y)
+        free = Blobs.init(bar.e, free, e_len, y)
         bar.c[] = c
         free
     end


### PR DESCRIPTION
Convert all generated functions to regular function.

- The produced code is mostly unchanged, and the perf remains the mostly the same.
- Type stability is tested by a new testitem

Runtime comparisons on julia 1.10:
```julia
julia> test_getproperty1(b) = b.e
test_getproperty1 (generic function with 1 method)

julia> @btime test_getproperty1($bar)      # BEFORE
  1.416 ns (0 allocations: 0 bytes)
Blob{Blob{Quux}}(Ptr{Nothing} @0x000000013f2d0ea0, 41, 361)

julia> @btime test_getproperty1($bar)      # AFTER
  1.416 ns (0 allocations: 0 bytes)
Blob{Blob{Quux}}(Ptr{Nothing} @0x000000013f2d0ea0, 41, 361)

julia> @btime unsafe_load($bar)      # BEFORE
  2.166 ns (0 allocations: 0 bytes)
Bar(10, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000013f2d0ea0, 217, 361))

julia> @btime unsafe_load($bar)      # AFTER
  1.791 ns (0 allocations: 0 bytes)
Bar(0, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000015590ae00, 217, 361))

julia> @btime unsafe_store!($bar, $bar_val)      # BEFORE
  5.250 ns (0 allocations: 0 bytes)
Bar(10, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000013f2d0ea0, 217, 361))

julia> @btime unsafe_store!($bar, $bar_val)      # AFTER
  9.667 ns (0 allocations: 0 bytes)
Bar(0, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000015590ae00, 217, 361))
```

Runtime comparisons on julia 1.11:
```julia
julia> test_getproperty1(b) = b.e
test_getproperty1 (generic function with 1 method)

julia> @btime test_getproperty1($bar)      # BEFORE
  2.042 ns (0 allocations: 0 bytes)
Blob{Blob{Quux}}(Ptr{Nothing} @0x000000013f959380, 41, 361)

julia> @btime test_getproperty1($bar)      # AFTER
  2.000 ns (0 allocations: 0 bytes)
Blob{Blob{Quux}}(Ptr{Nothing} @0x000000013f959380, 41, 361)

julia> @btime unsafe_load($bar)      # BEFORE
  2.333 ns (0 allocations: 0 bytes)
Bar(0, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000013f959380, 217, 361))

julia> @btime unsafe_load($bar)      # AFTER
  2.292 ns (0 allocations: 0 bytes)
Bar(0, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000013f959380, 217, 361))

julia> @btime unsafe_store!($bar, $bar_val)      # BEFORE
  5.250 ns (0 allocations: 0 bytes)
Bar(0, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000013f959380, 217, 361))

julia> @btime unsafe_store!($bar, $bar_val)      # AFTER
  5.333 ns (0 allocations: 0 bytes)
Bar(0, Bool[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], false, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], Blob{Quux}(Ptr{Nothing} @0x000000013f959380, 217, 361))
```
