### PR TITLE
Better bounds check

### DIFF
--- a/src/blob.jl
+++ b/src/blob.jl
@@ -41,8 +41,8 @@ function Base.:-(blob1::Blob, blob2::Blob)
     getfield(blob1, :offset) - getfield(blob2, :offset)
 end
 
-@inline function boundscheck(blob::Blob{T}) where T
-    @boundscheck begin
+function boundscheck(blob::Blob{T}) where T
+    begin
         if (getfield(blob, :offset) < 0) || (getfield(blob, :offset) + self_size(T) > getfield(blob, :limit))
             throw(BoundsError(blob))
         end
@@ -51,7 +51,7 @@ end
 end
 
 Base.@propagate_inbounds function Base.getindex(blob::Blob{T}) where T
-    boundscheck(blob)
+    @boundscheck boundscheck(blob)
     unsafe_load(blob)
 end
 
@@ -103,7 +103,7 @@ end
 end
 
 Base.@propagate_inbounds function Base.setindex!(blob::Blob{T}, value::T) where T
-    boundscheck(blob)
+    @boundscheck boundscheck(blob)
     unsafe_store!(blob, value)
 end
 


### PR DESCRIPTION
To get bounds checking, the current code relies on the `boundscheck` function getting inlined.

It should be enough to get the `getindex` (or `setindex!`) function inlined.  So those functions should declare the `@boundscheck`.

Move the `@boundscheck` declaration to `getindex` and `setindex!`.