### PR TITLE
Improve perf for dynamic index / fieldname (Restore the generated function perf)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Blobs"
 uuid = "163b9779-6631-5f90-a265-3de947924de8"
 authors = []
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -139,11 +139,11 @@ end
 # fieldindexes even for large structs (with e.g. 100 fields). This might make compiling a
 # touch slower, but it allows this to work for even large structs, like the manually-written
 # `@generated` functions did before.
-@inline function fieldindexes(::Type{T}) where {T,field}
+@inline function fieldindexes(::Type{T}) where {T}
     return _recursive_fieldindexes(T, Val(fieldcount(T)))
 end
-_recursive_fieldindexes(::Type{T}, ::Val{0}) where {T,field} = ()
-function _recursive_fieldindexes(::Type{T}, ::Val{i}) where {T,i,field}
+_recursive_fieldindexes(::Type{T}, ::Val{0}) where {T} = ()
+function _recursive_fieldindexes(::Type{T}, ::Val{i}) where {T,i}
     next = _recursive_fieldindexes(T, Val(i-1))
     names = (fieldnames(typeof(next))..., fieldname(T, i))
     return NamedTuple{names}((next..., i))

--- a/src/blob.jl
+++ b/src/blob.jl
@@ -150,7 +150,7 @@ function _recursive_fieldindexes(::Type{T}, ::Val{i}) where {T,i}
 end
 
 # NOTE: An important optimization here is that the static operations that can be performed
-# only on the top do not depend on the possibly runtime value `field`. We precompute the
+# only on the type do not depend on the possibly runtime value `field`. We precompute the
 # fieldname => fieldidx lookup table at compile time (as a NamedTuple), then use it at
 # runtime. If the field is a known compiler constant (as in the `x.y` case), all the better.
 @inline function Base.getindex(blob::Blob{T}, field::Symbol) where {T}

--- a/test/compat-tests.jl
+++ b/test/compat-tests.jl
@@ -42,7 +42,6 @@ bbv = Blobs.malloc_and_init(BlobBitVector, 3)
 pbv = @v bbv
 pbv[2] = true
 @test pbv[2] == true
-@test pv[2] == Foo(2, 2.2)
 pbv[1] = false
 pbv[3] = false
 # tests iteration


### PR DESCRIPTION
Fix a regression introduced in #28.

We need to do the field => index lookup at compiletime, but we cannot guarantee we'll get a compiler-constant fieldname.

So we precompute the entire lookup table (as a NamedTuple), then do the lookup in there. If the name is a compiler-constant, great, the lookup compiles away. But even if not, the lookup is very cheap.

Before:
```julia
julia> @btime getindex($foo, $2)
  209.277 ns (2 allocations: 48 bytes)
Blob{Float32}(Ptr{Nothing} @0x000000014b1feed0, 8, 12)

julia> @btime getproperty($foo, $(:x))
  1.833 μs (5 allocations: 176 bytes)
Blob{Int64}(Ptr{Nothing} @0x000000014b1feed0, 0, 12)

julia> @btime getproperty($foo, $(:y))
  1.275 μs (4 allocations: 128 bytes)
Blob{Float32}(Ptr{Nothing} @0x000000014b1feed0, 8, 12)
```

After:
```julia
julia> @btime getindex($foo, $2)
  85.196 ns (2 allocations: 48 bytes)
Blob{Float32}(Ptr{Nothing} @0x000000014b1feed0, 8, 12)

julia> @btime getproperty($foo, $(:x))
  99.912 ns (2 allocations: 48 bytes)
Blob{Int64}(Ptr{Nothing} @0x000000014b1feed0, 0, 12)

julia> @btime getproperty($foo, $(:y))
  107.028 ns (2 allocations: 48 bytes)
Blob{Float32}(Ptr{Nothing} @0x000000014b1feed0, 8, 12)
```

Probably the much more likely/relevant case would be a field-access on a type-unstable blobs value. For example `x.y` where `x` does not have a known type. This was very expensive before this PR:
```julia
julia> @btime ((a)->a[1].y)($(Any[foo]))
  1.458 μs (8 allocations: 352 bytes)
Blob{Float32}(Ptr{Nothing} @0x000000016fe73d90, 8, 12)
```
and now it's reasonable again:
```julia
julia> @btime ((a)->a[1].y)($(Any[foo]))
  115.105 ns (2 allocations: 48 bytes)
Blob{Float32}(Ptr{Nothing} @0x000000016fe73d90, 8, 12)
```