### PR TITLE
FINALLY add a benchmark script. We should've had this from the beginning.

### DIFF
--- a/bench/runbench.jl
+++ b/bench/runbench.jl
@@ -1,0 +1,33 @@
+using Blobs, BenchmarkTools
+
+@eval struct MixedStruct10
+    $((:($(Symbol("f$i"))::Float64) for i in 1:5)...)
+    $((:($(Symbol("x$i"))::Int64) for i in 1:5)...)
+end
+m10 = Blobs.malloc(MixedStruct10)
+
+@eval struct MixedStruct100
+    $((:($(Symbol("f$i"))::Float64) for i in 1:50)...)
+    $((:($(Symbol("x$i"))::Int64) for i in 1:50)...)
+end
+m100 = Blobs.malloc(MixedStruct100)
+
+@btime Blobs.malloc(MixedStruct10)
+@btime Blobs.malloc(MixedStruct100)
+
+@btime $(m10)[]
+@btime $(m100)[]
+
+@btime $(m10)[] = $(m10[])
+@btime $(m100)[] = $(m100[])
+
+@btime $(m10).x5[]
+@btime $(m100).x5[]
+@btime $(m100).x50[]
+
+@btime $(m10).f5[] = 0
+@btime $(m10).x5[] = 0
+@btime $(m100).f5[] = 0
+@btime $(m100).x5[] = 0
+@btime $(m100).x50[] = 0
+


### PR DESCRIPTION
This is the status as of now:
```julia
julia> include("bench/runbench.jl")
  11.000 ns (0 allocations: 0 bytes)
  61.641 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
  15.489 ns (0 allocations: 0 bytes)
  4.000 ns (0 allocations: 0 bytes)
  26.104 ns (0 allocations: 0 bytes)
  2.250 ns (0 allocations: 0 bytes)
  2.291 ns (0 allocations: 0 bytes)
  2.250 ns (0 allocations: 0 bytes)
  2.250 ns (0 allocations: 0 bytes)
  2.291 ns (0 allocations: 0 bytes)
  2.291 ns (0 allocations: 0 bytes)
  2.291 ns (0 allocations: 0 bytes)
  2.291 ns (0 allocations: 0 bytes)
0
```

(And here is the above benchmark run on v0.5.1 - when everything used `@generated` functions. You can see that we have recovered all of that performance.):
```julia
julia> include("bench/runbench.jl")
  10.844 ns (0 allocations: 0 bytes)
  62.855 ns (0 allocations: 0 bytes)
  3.041 ns (0 allocations: 0 bytes)
  16.074 ns (0 allocations: 0 bytes)
  4.416 ns (0 allocations: 0 bytes)
  26.230 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
  2.834 ns (0 allocations: 0 bytes)
  2.916 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
  2.833 ns (0 allocations: 0 bytes)
0
```