### PR TITLE
Make empty view on blobvector work

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Blobs"
 uuid = "163b9779-6631-5f90-a265-3de947924de8"
 authors = []
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -4,8 +4,9 @@ struct BlobVector{T} <: DenseArray{T, 1}
     length::Int64
 end
 
-function Base.pointer(bv::BlobVector{T}, i::Integer=1) where {T}
-    return get_address(bv, i)
+function Base.pointer(blob::BlobVector{T}, i::Integer=1) where {T}
+    # `pointer` is unsafe, and doesn't do a bounds check.
+    return blob.data + (i-1)*self_size(T)
 end
 
 Base.@propagate_inbounds function get_address(blob::BlobVector{T}, i::Int)::Blob{T} where T
@@ -50,14 +51,7 @@ end
 # For view, we don't need to make a `SubArray`, we can just make another Blob
 Base.@propagate_inbounds function Base.view(bv::BlobVector{T}, range) where T
     @boundscheck checkbounds(bv, range)
-    if isempty(range)
-        # Special-case when`first(range)` isn't a legal index.  This can happen on an empty
-        # range.  For example, for `view(two_element_blobvector, 3:2)`, `3` is not a legal
-        # pointer offset.
-        return BlobVector{T}(pointer(bv), 0)
-    else
-        return BlobVector{T}(pointer(bv, first(range)), length(range))
-    end
+    return BlobVector{T}(pointer(bv, first(range)), length(range))
 end
 
 # copying, with correct handling of overlapping regions

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -50,15 +50,7 @@ end
 # For view, we don't need to make a `SubArray`, we can just make another Blob
 Base.@propagate_inbounds function Base.view(bv::BlobVector{T}, range) where T
     @boundscheck checkbounds(bv, range)
-    blob = bv.data
-    return BlobVector{T}(
-        Blob{T}(
-            getfield(blob, :base) + (first(range)-1)*sizeof(T),
-            getfield(blob, :offset),
-            getfield(blob, :limit) - (first(range)-1)*sizeof(T),
-        ),
-        length(range),
-    )
+    return BlobVector{T}(pointer(bv, first(range)), length(range))
 end
 
 # copying, with correct handling of overlapping regions

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -50,7 +50,14 @@ end
 # For view, we don't need to make a `SubArray`, we can just make another Blob
 Base.@propagate_inbounds function Base.view(bv::BlobVector{T}, range) where T
     @boundscheck checkbounds(bv, range)
-    return BlobVector{T}(pointer(bv, first(range)), length(range))
+    if isempty(range)
+        # Special-case when`first(range)` isn't a legal index.  This can happen on an empty
+        # range.  For example, for `view(two_element_blobvector, 3:2)`, `3` is not a legal
+        # pointer offset.
+        return BlobVector{T}(pointer(bv), 0)
+    else
+        return BlobVector{T}(pointer(bv, first(range)), length(range))
+    end
 end
 
 # copying, with correct handling of overlapping regions

--- a/test/Blobs-tests.jl
+++ b/test/Blobs-tests.jl
@@ -75,6 +75,7 @@ if Base.JLOptions().check_bounds == 0
 end
 
 # view
+bv = BlobVector{Int64}(data, 3)
 bv[1] = 101
 bv[2] = 102
 bv[3] = 103
@@ -85,6 +86,7 @@ bv[3] = 103
 @test view(bv, 2:3) == [102,103]
 @test view(bv, 3:3) == [103]
 @test view(bv, 4:3) == []
+@info bv
 for lo in 1:4
     for hi in 0:3
         @test @view(bv[lo:hi]) == @view([101,102,103][lo:hi])

--- a/test/Blobs-tests.jl
+++ b/test/Blobs-tests.jl
@@ -85,6 +85,11 @@ bv[3] = 103
 @test view(bv, 2:3) == [102,103]
 @test view(bv, 3:3) == [103]
 @test view(bv, 4:3) == []
+for lo in 1:4
+    for hi in 0:3
+        @test @view(bv[lo:hi]) == @view([101,102,103][lo:hi])
+    end
+end
 
 bbv = Blobs.malloc_and_init(BlobVector{Foo}, 3)
 bv = bbv[]

--- a/test/Blobs-tests.jl
+++ b/test/Blobs-tests.jl
@@ -86,7 +86,6 @@ bv[3] = 103
 @test view(bv, 2:3) == [102,103]
 @test view(bv, 3:3) == [103]
 @test view(bv, 4:3) == []
-@info bv
 for lo in 1:4
     for hi in 0:3
         @test @view(bv[lo:hi]) == @view([101,102,103][lo:hi])


### PR DESCRIPTION
If `view(bv::BlobVector, range)` should not throw if `range` is empty, even if `first(range)` is out of bounds.

`pointer(::BlobVector)` doesn't check bounds (since `pointer` doesn't check bounds on arrays, for example).

By making out-of-range poiunters legal, it simplifies and speeds up `view`.

Ports the changes from 0.5.6 to main.