### PR TITLE
Port #56 to 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Blobs"
 uuid = "163b9779-6631-5f90-a265-3de947924de8"
 authors = []
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -4,8 +4,8 @@ struct BlobVector{T} <: DenseArray{T, 1}
     length::Int64
 end
 
-function Base.pointer(bv::BlobVector{T}, i::Integer=1) where {T}
-    return get_address(bv, i)
+function Base.pointer(blob::BlobVector{T}, i::Integer=1) where {T}
+    return blob.data + (i-1)*self_size(T)
 end
 
 Base.@propagate_inbounds function get_address(blob::BlobVector{T}, i::Int)::Blob{T} where T
@@ -50,14 +50,7 @@ end
 # For view, we don't need to make a `SubArray`, we can just make another `BlobVector`.
 Base.@propagate_inbounds function Base.view(bv::BlobVector{T}, range) where T
     @boundscheck checkbounds(bv, range)
-    if isempty(range)
-        # Special-case when`first(range)` isn't a legal index.  This can happen on an empty
-        # range.  For example, for `view(two_element_blobvector, 3:2)`, `3` is not a legal
-        # pointer offset.
-        return BlobVector{T}(pointer(bv), 0)
-    else
-        return BlobVector{T}(pointer(bv, first(range)), length(range))
-    end
+    return BlobVector{T}(pointer(bv, first(range)), length(range))
 end
 
 # copying, with correct handling of overlapping regions


### PR DESCRIPTION
`pointer(::BlobVector,...)` doesn't do a bounds check (just as `pointer` doesn't bounds check on `Vector`).

This simplifies and speeds up `view`.